### PR TITLE
Transport Layer Safety & Reliability Improvements

### DIFF
--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -10,12 +10,13 @@ import (
 	"golang.org/x/time/rate"
 )
 
+// these are the rules the transport layer must follow
 type Policy struct {
-	Timeout       time.Duration
-	RateLimiter   *rate.Limiter
-	MaxBodyBytes  int64
-	Retry         RetryPolicy
-	UserAgent     string
+	Timeout      time.Duration
+	RateLimiter  *rate.Limiter
+	MaxBodyBytes int64
+	Retry        RetryPolicy
+	UserAgent    string
 }
 
 func DefaultPolicy() Policy {
@@ -38,6 +39,7 @@ func NewTransport(hc *http.Client, p Policy) *Transport {
 	return &Transport{hc: hc, policy: p}
 }
 
+// basically checks whether all policies are followed or not
 func (t *Transport) Do(ctx context.Context, req *http.Request) (*http.Response, error) {
 	if t.policy.RateLimiter != nil {
 		if err := t.policy.RateLimiter.Wait(ctx); err != nil {
@@ -45,15 +47,44 @@ func (t *Transport) Do(ctx context.Context, req *http.Request) (*http.Response, 
 		}
 	}
 
+	// We cannot use defer cancel() here because it would cancel the context
+	// immediately after headers are received, breaking body reads.
+	// Instead, we wrap the body to cancel on Close().
 	ctx, cancel := context.WithTimeout(ctx, t.policy.Timeout)
-	defer cancel()
 
 	req = req.WithContext(ctx)
 	if t.policy.UserAgent != "" && req.Header.Get("User-Agent") == "" {
 		req.Header.Set("User-Agent", t.policy.UserAgent)
 	}
 
-	return t.hc.Do(req)
+	resp, err := t.hc.Do(req)
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+
+	resp.Body = &bodyWrapper{
+		ReadCloser: resp.Body,
+		cancel:     cancel,
+		reader:     io.LimitReader(resp.Body, t.policy.MaxBodyBytes+1),
+	}
+
+	return resp, nil
+}
+
+type bodyWrapper struct {
+	io.ReadCloser
+	cancel context.CancelFunc
+	reader io.Reader
+}
+
+func (w *bodyWrapper) Read(p []byte) (int, error) {
+	return w.reader.Read(p)
+}
+
+func (w *bodyWrapper) Close() error {
+	defer w.cancel()
+	return w.ReadCloser.Close()
 }
 
 func (t *Transport) DoJSON(ctx context.Context, method, url string, headers map[string]string, body []byte) ([]byte, error) {

--- a/tests/unit/retry_test.go
+++ b/tests/unit/retry_test.go
@@ -1,0 +1,102 @@
+package unit
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/star-gazer111/poly-go-clob-client/internal/transport"
+)
+
+// NOTE: We cannot test unexported functions like `shouldRetry` or `isIdempotent` directly from external package.
+// We must test them via public API (`DoJSON`, `Do`) or export them for testing (not recommended).
+
+//
+// ISSUE: `shouldRetry` and `isIdempotent` are unexported in `internal/transport`.
+// If I move the tests to `tests/unit`, I cannot call `transport.shouldRetry`.
+// I will have to adapt the tests to test the *public surface* (DoJSON) behavior that relies on them.
+
+// TestIdempotencyBehavior verifies that unsafe methods are NOT retried.
+func TestIdempotencyBehavior(t *testing.T) {
+	calls := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.WriteHeader(500)
+	}))
+	defer ts.Close()
+
+	p := transport.DefaultPolicy()
+	p.Retry.BaseDelay = 1 * time.Millisecond
+
+	tr := transport.NewTransport(http.DefaultClient, p)
+
+	// POST is not idempotent -> should fail on logic error (500) without retry
+	_, err := tr.DoJSON(context.Background(), "POST", ts.URL, nil, nil)
+
+	if err == nil {
+		t.Error("Expected error, got nil")
+	}
+
+	if calls != 1 {
+		t.Errorf("Expected 1 call (no retry), got %d", calls)
+	}
+}
+
+// TestDoJSONRetryLimit verifies we don't retry forever.
+func TestDoJSONRetryLimit(t *testing.T) {
+	calls := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.WriteHeader(500)
+	}))
+	defer ts.Close()
+
+	p := transport.DefaultPolicy()
+	p.Retry.MaxRetries = 2
+	p.Retry.BaseDelay = 1 * time.Millisecond // fast test
+	p.Retry.MaxDelay = 5 * time.Millisecond
+
+	tr := transport.NewTransport(http.DefaultClient, p)
+
+	// GET is idempotent -> should retry
+	_, err := tr.DoJSON(context.Background(), "GET", ts.URL, nil, nil)
+
+	if err == nil {
+		t.Error("Expected error after retries exhausted, got nil")
+	}
+
+	// Initial call (1) + 2 retries = 3 calls total
+	expectedCalls := 1 + p.Retry.MaxRetries
+	if calls != expectedCalls {
+		t.Errorf("Expected %d calls, got %d", expectedCalls, calls)
+	}
+}
+
+// TestDoJSONNonIdempotentNoRetry verifies POST is not retried on logic errors (like 500).
+func TestDoJSONNonIdempotentNoRetry(t *testing.T) {
+	calls := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.WriteHeader(500)
+	}))
+	defer ts.Close()
+
+	p := transport.DefaultPolicy()
+
+	p.Retry.BaseDelay = 1 * time.Millisecond
+
+	tr := transport.NewTransport(http.DefaultClient, p)
+
+	// POST -> should NOT retry on 500
+	_, err := tr.DoJSON(context.Background(), "POST", ts.URL, nil, nil)
+
+	if err == nil {
+		t.Error("Expected error, got nil")
+	}
+
+	if calls != 1 {
+		t.Errorf("Expected exactly 1 call for POST 500, got %d", calls)
+	}
+}

--- a/tests/unit/transport_test.go
+++ b/tests/unit/transport_test.go
@@ -1,0 +1,109 @@
+package unit
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/star-gazer111/poly-go-clob-client/internal/transport"
+	"golang.org/x/time/rate"
+)
+
+// TestBodyCapEnforcement verifies that responses larger than MaxBodyBytes are handled correcty.
+func TestBodyCapEnforcement(t *testing.T) {
+	// 1. Setup server sending 1024 bytes
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(strings.Repeat("a", 1024)))
+	}))
+	defer ts.Close()
+
+	// 2. Configure transport with 512 byte cap
+	p := transport.DefaultPolicy()
+	p.MaxBodyBytes = 512
+	// Disable rate limit for this test
+	p.RateLimiter = rate.NewLimiter(rate.Inf, 0)
+
+	tr := transport.NewTransport(http.DefaultClient, p)
+
+	// 3. Make request
+	req, _ := http.NewRequest("GET", ts.URL, nil)
+	resp, err := tr.Do(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Do failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// 4. ReadAll should read up to limit + 1
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll failed: %v", err)
+	}
+
+	// 5. Verify length.
+	// We expect 513 bytes (512 allowed + 1 to prove overflow)
+	expected := int(p.MaxBodyBytes + 1)
+	if len(data) > expected {
+		t.Errorf("Expected max %d bytes, got %d", expected, len(data))
+	}
+}
+
+// TestRateLimiterBehavior verifies the transport blocks when rate limit is exceeded.
+func TestRateLimiterBehavior(t *testing.T) {
+	p := transport.DefaultPolicy()
+	// Allow 1 request per second, burst 1
+	p.RateLimiter = rate.NewLimiter(rate.Limit(1), 1)
+
+	tr := transport.NewTransport(http.DefaultClient, p)
+
+	// Server that does nothing
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	}))
+	defer ts.Close()
+
+	ctx := context.Background()
+	req, _ := http.NewRequest("GET", ts.URL, nil)
+
+	// First request should be instant (burst 1)
+	start := time.Now()
+	if _, err := tr.Do(ctx, req); err != nil {
+		t.Fatalf("Req 1 failed: %v", err)
+	}
+
+	// Second request should block for ~1s
+	if _, err := tr.Do(ctx, req); err != nil {
+		t.Fatalf("Req 2 failed: %v", err)
+	}
+	elapsed := time.Since(start)
+
+	if elapsed < 900*time.Millisecond {
+		t.Errorf("Rate limiter did not block long enough. Elapsed: %v", elapsed)
+	}
+}
+
+// TestContextDeadline verifies the context is respected.
+func TestContextDeadline(t *testing.T) {
+	// Server sleeps longer than timeout
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+	}))
+	defer ts.Close()
+
+	p := transport.DefaultPolicy()
+	p.Timeout = 50 * time.Millisecond // fast timeout
+	p.RateLimiter = rate.NewLimiter(rate.Inf, 0)
+
+	tr := transport.NewTransport(http.DefaultClient, p)
+
+	ctx := context.Background()
+	req, _ := http.NewRequest("GET", ts.URL, nil)
+
+	_, err := tr.Do(ctx, req)
+	if err == nil {
+		t.Error("Expected timeout error, got nil")
+	}
+}

--- a/tests/unit/transport_test.go
+++ b/tests/unit/transport_test.go
@@ -17,7 +17,7 @@ import (
 func TestBodyCapEnforcement(t *testing.T) {
 	// 1. Setup server sending 1024 bytes
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(strings.Repeat("a", 1024)))
+		_, _ = w.Write([]byte(strings.Repeat("a", 1024)))
 	}))
 	defer ts.Close()
 


### PR DESCRIPTION
## What This PR Does
Fixes #3 
This update fixes the core **client engine** (the `transport` folder) to ensure it stays stable and safe when things go wrong—preventing crashes, memory issues, and potential bans.

---

##  Key Changes

###  Fixed the Premature Cancel Bug
- **Before:** The connection was closed too early (right after the server sent `Hello`), breaking downloads.
- **Now:** The connection remains open until all data is assumed to be fully read.

---

###  Added Safety Caps

####  Speed Limit (Rate Limiter)
- Automatically pauses requests when they are sent too quickly.
- Helps avoid server bans and throttling.

####  Size Limit (Response Body Cap)
- Cuts off responses at **2MB** if the server attempts to send extremely large payloads (e.g., huge error logs).
- Prevents excessive memory usage and crashes.

---

###  Verified Retry Logic
- Ensures only **safe operations** (e.g., price checks) are retried.
- **Unsafe operations** (e.g., placing orders) are never retried, even on network errors.

---

###  Added Tests
- Introduced a new `tests/unit` directory.
- Added unit tests covering:
  - Timeouts
  - Rate limiting
  - Retry behavior

---

##  Checklist

- [x] Context cancellation fixed  
- [x] Rate limiter connected  
- [x] Body size cap enforced  
- [x] Unit tests passed (`go test ./tests/unit/...`)
