### PR TITLE
Add Price, Spread, and History Endpoints with Integration Tests

### DIFF
--- a/clob/l1_client.go
+++ b/clob/l1_client.go
@@ -1,17 +1,20 @@
 package clob
 
-import (
-	"github.com/star-gazer111/poly-go-clob-client/auth"
-)
+import "github.com/star-gazer111/poly-go-clob-client/auth"
 
 type L1Client struct {
 	*PublicClient
 	signer auth.Signer
 }
 
-func NewL1Client(baseURL string, signer auth.Signer, opts ...PublicClientOption) *L1Client {
-	return &L1Client{
-		PublicClient: NewPublicClient(baseURL, opts...),
-		signer:       signer,
+func NewL1Client(baseURL string, signer auth.Signer, opts ...PublicClientOption) (*L1Client, error) {
+	pc, err := NewPublicClient(baseURL, opts...)
+	if err != nil {
+		return nil, err
 	}
+
+	return &L1Client{
+		PublicClient: pc,
+		signer:       signer,
+	}, nil
 }

--- a/clob/l2_client.go
+++ b/clob/l2_client.go
@@ -1,17 +1,20 @@
 package clob
 
-import (
-	"github.com/star-gazer111/poly-go-clob-client/auth"
-)
+import "github.com/star-gazer111/poly-go-clob-client/auth"
 
 type L2Client struct {
 	*PublicClient
 	creds auth.APICreds
 }
 
-func NewL2Client(baseURL string, creds auth.APICreds, opts ...PublicClientOption) *L2Client {
-	return &L2Client{
-		PublicClient: NewPublicClient(baseURL, opts...),
-		creds:        creds,
+func NewL2Client(baseURL string, creds auth.APICreds, opts ...PublicClientOption) (*L2Client, error) {
+	pc, err := NewPublicClient(baseURL, opts...)
+	if err != nil {
+		return nil, err
 	}
+
+	return &L2Client{
+		PublicClient: pc,
+		creds:        creds,
+	}, nil
 }

--- a/clob/public_client.go
+++ b/clob/public_client.go
@@ -210,6 +210,28 @@ func (c *PublicClient) GetLastTradesPrices(ctx context.Context, req []types.Last
 	return resp, nil
 }
 
+func (c *PublicClient) GetMarketTradesEvents(ctx context.Context, req *types.GetMarketTradesEventsRequest) (*types.MarketTradesEventsResponse, error) {
+	u := c.endpoint("/events/trade")
+	q := url.Values{}
+	q.Add("condition_id", req.ConditionID)
+	if req.NextCursor != "" {
+		q.Add("next_cursor", req.NextCursor)
+	}
+	u = u + "?" + q.Encode()
+
+	b, err := c.transport.DoJSON(ctx, http.MethodGet, u, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp types.MarketTradesEventsResponse
+	if err := json.Unmarshal(b, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
 func (c *PublicClient) OrderBooks(ctx context.Context, req []types.OrderBookSummaryRequest) ([]*types.OrderBookSummaryResponse, error) {
 	u := c.endpoint("/books")
 

--- a/clob/public_client.go
+++ b/clob/public_client.go
@@ -150,7 +150,7 @@ func (c *PublicClient) OrderBook(ctx context.Context, req *types.OrderBookSummar
 	q.Add("side", fmt.Sprintf("%d", req.Side))
 
 	// Construct URL with query params
-	u := c.endpoint("/order_book_summary")
+	u := c.endpoint("/book")
 	if len(q) > 0 {
 		u = u + "?" + q.Encode()
 	}
@@ -166,4 +166,26 @@ func (c *PublicClient) OrderBook(ctx context.Context, req *types.OrderBookSummar
 	}
 
 	return &resp, nil
+}
+
+func (c *PublicClient) OrderBooks(ctx context.Context, req []types.OrderBookSummaryRequest) ([]*types.OrderBookSummaryResponse, error) {
+	u := c.endpoint("/books")
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+
+	b, err := c.transport.DoJSON(ctx, http.MethodPost, u, nil, body)
+
+	if err != nil {
+		return nil, err
+	}
+
+	var resp []*types.OrderBookSummaryResponse
+	if err := json.Unmarshal(b, &resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
 }

--- a/clob/public_client.go
+++ b/clob/public_client.go
@@ -189,3 +189,19 @@ func (c *PublicClient) OrderBooks(ctx context.Context, req []types.OrderBookSumm
 
 	return resp, nil
 }
+
+func (c *PublicClient) GetMarket(ctx context.Context, req *types.MarketRequest) (*types.MarketResponse, error) {
+	u := c.endpoint(fmt.Sprintf("/markets/%s", req.ConditionID))
+
+	b, err := c.transport.DoJSON(ctx, http.MethodGet, u, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp types.MarketResponse
+	if err := json.Unmarshal(b, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}

--- a/clob/public_client.go
+++ b/clob/public_client.go
@@ -189,6 +189,27 @@ func (c *PublicClient) GetLastTradePrice(ctx context.Context, req *types.LastTra
 	return &resp, nil
 }
 
+func (c *PublicClient) GetLastTradesPrices(ctx context.Context, req []types.LastTradePriceRequest) ([]*types.LastTradePriceResponse, error) {
+	u := c.endpoint("/last-trades-prices")
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+
+	b, err := c.transport.DoJSON(ctx, http.MethodGet, u, nil, body)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp []*types.LastTradePriceResponse
+	if err := json.Unmarshal(b, &resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
 func (c *PublicClient) OrderBooks(ctx context.Context, req []types.OrderBookSummaryRequest) ([]*types.OrderBookSummaryResponse, error) {
 	u := c.endpoint("/books")
 

--- a/clob/public_client.go
+++ b/clob/public_client.go
@@ -226,3 +226,24 @@ func (c *PublicClient) Markets(ctx context.Context, nextCursor string) (*types.M
 
 	return &resp, nil
 }
+
+// SimplifiedMarkets fetches a paginated list of simplified markets.
+// Pass an empty string for nextCursor to get the first page.
+func (c *PublicClient) SimplifiedMarkets(ctx context.Context, nextCursor string) (*types.SimplifiedMarketsPage, error) {
+	u := c.endpoint("/simplified-markets")
+	if nextCursor != "" {
+		u = u + "?next_cursor=" + url.QueryEscape(nextCursor)
+	}
+
+	b, err := c.transport.DoJSON(ctx, http.MethodGet, u, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp types.SimplifiedMarketsPage
+	if err := json.Unmarshal(b, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}

--- a/clob/public_client.go
+++ b/clob/public_client.go
@@ -2,43 +2,140 @@ package clob
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
+	"net/url"
+	"strings"
 
 	"github.com/star-gazer111/poly-go-clob-client/internal/transport"
+	"github.com/star-gazer111/poly-go-clob-client/types"
 )
 
 type PublicClient struct {
-	baseURL   string
-	transport *transport.Transport
+	baseURL      *url.URL
+	transport    *transport.Transport
+	requireHTTPS bool
 }
 
+// PublicClientOption configures the PublicClient
 type PublicClientOption func(*PublicClient)
 
-func NewPublicClient(baseURL string, opts ...PublicClientOption) *PublicClient {
-	c := &PublicClient{
-		baseURL:   baseURL,
-		transport: transport.NewTransport(http.DefaultClient, transport.DefaultPolicy()),
+// WithTransport sets a custom transport 
+func WithTransport(t *transport.Transport) PublicClientOption {
+	return func(c *PublicClient) {
+		if t != nil {
+			c.transport = t
+		}
 	}
+}
+
+// WithHTTPClient sets a custom http.Client while preserving default transport policy
+func WithHTTPClient(hc *http.Client) PublicClientOption {
+	return func(c *PublicClient) {
+		if hc != nil {
+			c.transport = transport.NewTransport(hc, transport.DefaultPolicy())
+		}
+	}
+}
+
+// WithRequireHTTPS enforces https scheme for baseURL.
+func WithRequireHTTPS(require bool) PublicClientOption {
+	return func(c *PublicClient) {
+		c.requireHTTPS = require
+	}
+}
+
+// NewPublicClient constructs a public-only client
+//
+// - baseURL must be a valid URL (non-empty)
+// - https is recommended we can optionally enforce via WithRequireHTTPS(true)
+func NewPublicClient(baseURL string, opts ...PublicClientOption) (*PublicClient, error) {
+	c := &PublicClient{
+		transport:    transport.NewTransport(http.DefaultClient, transport.DefaultPolicy()),
+		requireHTTPS: false,
+	}
+
 	for _, opt := range opts {
 		opt(c)
 	}
-	return c
-}
 
-func WithHTTPClient(hc *http.Client) PublicClientOption {
-	return func(c *PublicClient) {
-		c.transport = transport.NewTransport(hc, transport.DefaultPolicy())
+	u, err := validateBaseURL(baseURL, c.requireHTTPS)
+	if err != nil {
+		return nil, err
 	}
+	c.baseURL = u
+	return c, nil
 }
 
-func WithTransport(t *transport.Transport) PublicClientOption {
-	return func(c *PublicClient) {
-		c.transport = t
+func validateBaseURL(baseURL string, requireHTTPS bool) (*url.URL, error) {
+	baseURL = strings.TrimSpace(baseURL)
+	if baseURL == "" {
+		return nil, types.ValidationErr("baseURL must be non-empty")
 	}
+
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, types.WithSource(types.KindValidation, err)
+	}
+
+	// must have scheme + host
+	if u.Scheme == "" || u.Host == "" {
+		return nil, types.ValidationErr("baseURL must include scheme and host (e.g., https://example.com)")
+	}
+
+	// https. Allow http for local/testing
+	if requireHTTPS && strings.ToLower(u.Scheme) != "https" {
+		return nil, types.ValidationErr("baseURL must use https scheme")
+	}
+
+	// we normalize: remove trailing slash path unless user has custom base path
+	// and we keep any non-root path if present 
+	if u.Path == "/" {
+		u.Path = ""
+	}
+	u.RawQuery = ""
+	u.Fragment = ""
+
+	return u, nil
 }
 
-// Example public method placeholder
-func (c *PublicClient) Ping(ctx context.Context) error {
-	_, err := c.transport.DoJSON(ctx, http.MethodGet, c.baseURL+"/ping", nil, nil)
-	return err
+func (c *PublicClient) endpoint(path string) string {
+	// path should start with "/" for correctness
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	// preserve baseURL path prefix if present
+	base := *c.baseURL
+	base.Path = strings.TrimRight(base.Path, "/") + path
+	return base.String()
+}
+
+// PingResponse is a minimal response model - kept it intentionally small for v0.1
+type PingResponse struct {
+	Message string `json:"message,omitempty"`
+	Status  string `json:"status,omitempty"`
+	OK      bool   `json:"ok,omitempty"`
+	Raw     string `json:"-"`
+}
+
+// ping calls a simple public endpoint (e.g. /ping) and returns a parsed response
+// if the server returns JSON we parse it otherwise we return raw string
+//
+// this is meant as a boring smoke-test endpoint for transport + error typing
+func (c *PublicClient) Ping(ctx context.Context) (*PingResponse, error) {
+	b, err := c.transport.DoJSON(ctx, http.MethodGet, c.endpoint("/ping"), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := &PingResponse{}
+	// try JSON first
+	if json.Unmarshal(b, resp) == nil {
+		return resp, nil
+	}
+
+	// fallback: treat as plain text
+	resp.Raw = strings.TrimSpace(string(b))
+	resp.OK = resp.Raw != ""
+	return resp, nil
 }

--- a/clob/public_client.go
+++ b/clob/public_client.go
@@ -247,3 +247,24 @@ func (c *PublicClient) SimplifiedMarkets(ctx context.Context, nextCursor string)
 
 	return &resp, nil
 }
+
+// SamplingMarkets fetches a paginated list of sampling markets.
+// Pass an empty string for nextCursor to get the first page.
+func (c *PublicClient) SamplingMarkets(ctx context.Context, nextCursor string) (*types.MarketsPage, error) {
+	u := c.endpoint("/sampling-markets")
+	if nextCursor != "" {
+		u = u + "?next_cursor=" + url.QueryEscape(nextCursor)
+	}
+
+	b, err := c.transport.DoJSON(ctx, http.MethodGet, u, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp types.MarketsPage
+	if err := json.Unmarshal(b, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}

--- a/clob/public_client.go
+++ b/clob/public_client.go
@@ -190,7 +190,7 @@ func (c *PublicClient) OrderBooks(ctx context.Context, req []types.OrderBookSumm
 	return resp, nil
 }
 
-func (c *PublicClient) GetMarket(ctx context.Context, req *types.MarketRequest) (*types.MarketResponse, error) {
+func (c *PublicClient) Market(ctx context.Context, req *types.MarketRequest) (*types.MarketResponse, error) {
 	u := c.endpoint(fmt.Sprintf("/markets/%s", req.ConditionID))
 
 	b, err := c.transport.DoJSON(ctx, http.MethodGet, u, nil, nil)
@@ -199,6 +199,27 @@ func (c *PublicClient) GetMarket(ctx context.Context, req *types.MarketRequest) 
 	}
 
 	var resp types.MarketResponse
+	if err := json.Unmarshal(b, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+// Markets fetches a paginated list of all markets.
+// Pass an empty string for nextCursor to get the first page.
+func (c *PublicClient) Markets(ctx context.Context, nextCursor string) (*types.MarketsPage, error) {
+	u := c.endpoint("/markets")
+	if nextCursor != "" {
+		u = u + "?next_cursor=" + url.QueryEscape(nextCursor)
+	}
+
+	b, err := c.transport.DoJSON(ctx, http.MethodGet, u, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp types.MarketsPage
 	if err := json.Unmarshal(b, &resp); err != nil {
 		return nil, err
 	}

--- a/clob/public_client.go
+++ b/clob/public_client.go
@@ -168,6 +168,27 @@ func (c *PublicClient) OrderBook(ctx context.Context, req *types.OrderBookSummar
 	return &resp, nil
 }
 
+func (c *PublicClient) GetLastTradePrice(ctx context.Context, req *types.LastTradePriceRequest) (*types.LastTradePriceResponse, error) {
+	q := url.Values{}
+	q.Add("token_id", req.TokenId)
+
+	u := c.endpoint("/last-trade-price")
+	if len(q) > 0 {
+		u = u + "?" + q.Encode()
+	}
+	b, err := c.transport.DoJSON(ctx, http.MethodGet, u, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp types.LastTradePriceResponse
+	if err := json.Unmarshal(b, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
 func (c *PublicClient) OrderBooks(ctx context.Context, req []types.OrderBookSummaryRequest) ([]*types.OrderBookSummaryResponse, error) {
 	u := c.endpoint("/books")
 

--- a/clob/public_client.go
+++ b/clob/public_client.go
@@ -268,3 +268,24 @@ func (c *PublicClient) SamplingMarkets(ctx context.Context, nextCursor string) (
 
 	return &resp, nil
 }
+
+// SamplingSimplifiedMarkets fetches a paginated list of sampling simplified markets.
+// Pass an empty string for nextCursor to get the first page.
+func (c *PublicClient) SamplingSimplifiedMarkets(ctx context.Context, nextCursor string) (*types.SimplifiedMarketsPage, error) {
+	u := c.endpoint("/sampling-simplified-markets")
+	if nextCursor != "" {
+		u = u + "?next_cursor=" + url.QueryEscape(nextCursor)
+	}
+
+	b, err := c.transport.DoJSON(ctx, http.MethodGet, u, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp types.SimplifiedMarketsPage
+	if err := json.Unmarshal(b, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}

--- a/clob/public_client.go
+++ b/clob/public_client.go
@@ -119,12 +119,12 @@ type PingResponse struct {
 	Raw     string `json:"-"`
 }
 
-// ping calls a simple public endpoint (e.g. /ping) and returns a parsed response
-// if the server returns JSON we parse it otherwise we return raw string
+// Ping calls the root endpoint as a health check and returns a parsed response.
+// If the server returns JSON we parse it, otherwise we return raw string.
 //
-// this is meant as a boring smoke-test endpoint for transport + error typing
+// This is meant as a smoke-test endpoint for transport + error typing.
 func (c *PublicClient) Ping(ctx context.Context) (*PingResponse, error) {
-	b, err := c.transport.DoJSON(ctx, http.MethodGet, c.endpoint("/ping"), nil, nil)
+	b, err := c.transport.DoJSON(ctx, http.MethodGet, c.endpoint("/"), nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -143,7 +143,7 @@ func (c *PublicClient) Ping(ctx context.Context) (*PingResponse, error) {
 
 func (c *PublicClient) OrderBook(ctx context.Context, req *types.OrderBookSummaryRequest) (*types.OrderBookSummaryResponse, error) {
 	q := url.Values{}
-	q.Add("token_id", fmt.Sprintf("%d", req.TokenId))
+	q.Add("token_id", req.TokenId)
 
 	// Side is int, so we send as "0" (Buy) or "1" (Sell)
 

--- a/clob/public_client.go
+++ b/clob/public_client.go
@@ -119,12 +119,12 @@ type PingResponse struct {
 	Raw     string `json:"-"`
 }
 
-// Ping calls the root endpoint as a health check and returns a parsed response.
+// Ping calls the "/ping" endpoint as a health check and returns a parsed response.
 // If the server returns JSON we parse it, otherwise we return raw string.
 //
 // This is meant as a smoke-test endpoint for transport + error typing.
 func (c *PublicClient) Ping(ctx context.Context) (*PingResponse, error) {
-	b, err := c.transport.DoJSON(ctx, http.MethodGet, c.endpoint("/"), nil, nil)
+	b, err := c.transport.DoJSON(ctx, http.MethodGet, c.endpoint("/ping"), nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/clob/public_client.go
+++ b/clob/public_client.go
@@ -111,6 +111,16 @@ func (c *PublicClient) endpoint(path string) string {
 	return base.String()
 }
 
+// endpointWithQuery builds the full URL for path and appends q as a query string.
+// If q is empty the bare endpoint is returned unchanged.
+func (c *PublicClient) endpointWithQuery(path string, q url.Values) string {
+	u := c.endpoint(path)
+	if len(q) > 0 {
+		u = u + "?" + q.Encode()
+	}
+	return u
+}
+
 // PingResponse is a minimal response model - kept it intentionally small for v0.1
 type PingResponse struct {
 	Message string `json:"message,omitempty"`
@@ -124,7 +134,7 @@ type PingResponse struct {
 //
 // This is meant as a smoke-test endpoint for transport + error typing.
 func (c *PublicClient) Ping(ctx context.Context) (*PingResponse, error) {
-	b, err := c.transport.DoJSON(ctx, http.MethodGet, c.endpoint("/ping"), nil, nil)
+	b, err := c.transport.DoJSON(ctx, http.MethodGet, c.endpoint("/"), nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -150,10 +160,7 @@ func (c *PublicClient) OrderBook(ctx context.Context, req *types.OrderBookSummar
 	q.Add("side", fmt.Sprintf("%d", req.Side))
 
 	// Construct URL with query params
-	u := c.endpoint("/book")
-	if len(q) > 0 {
-		u = u + "?" + q.Encode()
-	}
+	u := c.endpointWithQuery("/book", q)
 
 	b, err := c.transport.DoJSON(ctx, http.MethodGet, u, nil, nil)
 	if err != nil {
@@ -172,10 +179,7 @@ func (c *PublicClient) GetLastTradePrice(ctx context.Context, req *types.LastTra
 	q := url.Values{}
 	q.Add("token_id", req.TokenId)
 
-	u := c.endpoint("/last-trade-price")
-	if len(q) > 0 {
-		u = u + "?" + q.Encode()
-	}
+	u := c.endpointWithQuery("/last-trade-price", q)
 	b, err := c.transport.DoJSON(ctx, http.MethodGet, u, nil, nil)
 	if err != nil {
 		return nil, err
@@ -358,10 +362,7 @@ func (c *PublicClient) Midpoint(ctx context.Context, req *types.MidpointRequest)
 	q := url.Values{}
 	q.Add("token_id", req.TokenId)
 
-	u := c.endpoint("/midpoint")
-	if len(q) > 0 {
-		u = u + "?" + q.Encode()
-	}
+	u := c.endpointWithQuery("/midpoint", q)
 
 	b, err := c.transport.DoJSON(ctx, http.MethodGet, u, nil, nil)
 	if err != nil {
@@ -403,10 +404,7 @@ func (c *PublicClient) GetPrice(ctx context.Context, req types.PriceRequest) (ty
 	q.Add("token_id", req.TokenId)
 	q.Add("side", req.Side)
 
-	u := c.endpoint("/price")
-	if len(q) > 0 {
-		u = u + "?" + q.Encode()
-	}
+	u := c.endpointWithQuery("/price", q)
 
 	b, err := c.transport.DoJSON(ctx, http.MethodGet, u, nil, nil)
 	if err != nil {
@@ -449,10 +447,7 @@ func (c *PublicClient) GetSpread(ctx context.Context, req types.SpreadRequest) (
 		q.Add("side", fmt.Sprintf("%d", *req.Side))
 	}
 
-	u := c.endpoint("/spread")
-	if len(q) > 0 {
-		u = u + "?" + q.Encode()
-	}
+	u := c.endpointWithQuery("/spread", q)
 
 	b, err := c.transport.DoJSON(ctx, http.MethodGet, u, nil, nil)
 	if err != nil {
@@ -515,10 +510,7 @@ func (c *PublicClient) GetPricesHistory(ctx context.Context, req types.PricesHis
 		q.Add("fidelity", fmt.Sprintf("%d", *req.Fidelity))
 	}
 
-	u := c.endpoint("/prices-history")
-	if len(q) > 0 {
-		u = u + "?" + q.Encode()
-	}
+	u := c.endpointWithQuery("/prices-history", q)
 
 	b, err := c.transport.DoJSON(ctx, http.MethodGet, u, nil, nil)
 	if err != nil {

--- a/clob/public_client_integration_test.go
+++ b/clob/public_client_integration_test.go
@@ -392,3 +392,38 @@ func TestIntegration_AllEndpointsReachable(t *testing.T) {
 		})
 	}
 }
+
+// TestIntegration_GetLastTradePrice tests the /last-trade-price endpoint.
+func TestIntegration_GetLastTradePrice(t *testing.T) {
+	c := getTestClient(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultTimeout)
+	defer cancel()
+
+	// Fetch token_id from Gamma API
+	tokenID, err := fetchTokenIDFromGamma(ctx)
+	if err != nil {
+		t.Skipf("Could not fetch token_id from Gamma API: %v", err)
+	}
+
+	t.Logf("Testing GetLastTradePrice with token_id: %s", tokenID)
+
+	req := &types.LastTradePriceRequest{
+		TokenId: tokenID,
+	}
+
+	resp, err := c.GetLastTradePrice(ctx, req)
+	if err != nil {
+		t.Fatalf("GetLastTradePrice failed: %v", err)
+	}
+
+	t.Logf("GetLastTradePrice response: Price=%s, Side=%v", resp.Price, resp.Side)
+
+	if resp.Price.String() == "" {
+		t.Error("Expected price to be present")
+	}
+
+	if resp.Side != "BUY" && resp.Side != "SELL" {
+		t.Errorf("Expected Side to be 'BUY' or 'SELL', got '%s'", resp.Side)
+	}
+}

--- a/clob/public_client_integration_test.go
+++ b/clob/public_client_integration_test.go
@@ -427,3 +427,38 @@ func TestIntegration_GetLastTradePrice(t *testing.T) {
 		t.Errorf("Expected Side to be 'BUY' or 'SELL', got '%s'", resp.Side)
 	}
 }
+
+// TestIntegration_GetLastTradesPrices tests the /last-trades-prices endpoint.
+func TestIntegration_GetLastTradesPrices(t *testing.T) {
+	c := getTestClient(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultTimeout)
+	defer cancel()
+
+	// Fetch token_id from Gamma API
+	tokenID, err := fetchTokenIDFromGamma(ctx)
+	if err != nil {
+		t.Skipf("Could not fetch token_id from Gamma API: %v", err)
+	}
+
+	t.Logf("Testing GetLastTradesPrices with token_id: %s", tokenID)
+
+	req := []types.LastTradePriceRequest{
+		{TokenId: tokenID},
+	}
+
+	resp, err := c.GetLastTradesPrices(ctx, req)
+	if err != nil {
+		t.Fatalf("GetLastTradesPrices failed: %v", err)
+	}
+
+	if len(resp) == 0 {
+		t.Fatal("Expected at least one response")
+	}
+
+	t.Logf("GetLastTradesPrices response: %+v", resp[0])
+
+	if resp[0].Price.String() == "" {
+		t.Error("Expected price to be present")
+	}
+}

--- a/clob/public_client_integration_test.go
+++ b/clob/public_client_integration_test.go
@@ -462,3 +462,52 @@ func TestIntegration_GetLastTradesPrices(t *testing.T) {
 		t.Error("Expected price to be present")
 	}
 }
+
+// TestIntegration_GetMarketTradesEvents tests the /events/trade endpoint.
+func TestIntegration_GetMarketTradesEvents(t *testing.T) {
+	c := getTestClient(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultTimeout)
+	defer cancel()
+
+	// Fetch token_id from Gamma API to get a valid condition_id
+	// Note: We need a condition_id, and fetchTokenIDFromGamma returns a token_id.
+	// For simplicity, we'll fetch markets and use the first one's condition_id.
+
+	markets, err := c.Markets(ctx, "")
+	if err != nil {
+		t.Fatalf("Markets failed: %v", err)
+	}
+	if len(markets.Data) == 0 {
+		t.Skip("No markets available to test GetMarketTradesEvents")
+	}
+
+	var conditionID string
+	for _, m := range markets.Data {
+		if m.ConditionID != nil && *m.ConditionID != "" {
+			conditionID = *m.ConditionID
+			break
+		}
+	}
+
+	if conditionID == "" {
+		t.Skip("No valid condition_id found")
+	}
+
+	t.Logf("Testing GetMarketTradesEvents with condition_id: %s", conditionID)
+
+	req := &types.GetMarketTradesEventsRequest{
+		ConditionID: conditionID,
+	}
+
+	resp, err := c.GetMarketTradesEvents(ctx, req)
+	if err != nil {
+		t.Fatalf("GetMarketTradesEvents failed: %v", err)
+	}
+
+	t.Logf("GetMarketTradesEvents response: next_cursor=%s, count=%d", resp.NextCursor, len(resp.Data))
+
+	if len(resp.Data) > 0 {
+		t.Logf("First trade event: %+v", resp.Data[0])
+	}
+}

--- a/clob/public_client_integration_test.go
+++ b/clob/public_client_integration_test.go
@@ -1,0 +1,394 @@
+//go:build integration
+// +build integration
+
+package clob
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/star-gazer111/poly-go-clob-client/types"
+)
+
+const (
+	// LiveBaseURL is the Polymarket CLOB API base URL.
+	LiveBaseURL = "https://clob.polymarket.com"
+	// DefaultTimeout for API calls.
+	DefaultTimeout = 30 * time.Second
+)
+
+// getTestClient returns a PublicClient configured for live testing.
+func getTestClient(t *testing.T) *PublicClient {
+	t.Helper()
+
+	baseURL := os.Getenv("POLYMARKET_CLOB_URL")
+	if baseURL == "" {
+		baseURL = LiveBaseURL
+	}
+
+	c, err := NewPublicClient(baseURL, WithRequireHTTPS(true))
+	if err != nil {
+		t.Fatalf("NewPublicClient: %v", err)
+	}
+	return c
+}
+
+// TestIntegration_Ping tests the root endpoint as a health check against the live API.
+func TestIntegration_Ping(t *testing.T) {
+	c := getTestClient(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultTimeout)
+	defer cancel()
+
+	resp, err := c.Ping(ctx)
+	if err != nil {
+		t.Fatalf("Ping failed: %v", err)
+	}
+
+	t.Logf("Ping response: %+v", resp)
+	if resp == nil {
+		t.Fatal("expected non-nil ping response")
+	}
+}
+
+// TestIntegration_Markets tests the /markets endpoint against the live API.
+func TestIntegration_Markets(t *testing.T) {
+	c := getTestClient(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultTimeout)
+	defer cancel()
+
+	resp, err := c.Markets(ctx, "")
+	fmt.Println(resp)
+	if err != nil {
+		t.Fatalf("Markets failed: %v", err)
+	}
+
+	t.Logf("Markets response: Count=%d, Limit=%d, NextCursor=%s", resp.Count, resp.Limit, resp.NextCursor)
+
+	if resp.Count == 0 {
+		t.Log("Warning: No markets returned from the API")
+	}
+
+	// Validate pagination works
+	if resp.NextCursor != "" && resp.Count > 0 {
+		t.Logf("First market condition_id: %v", resp.Data[0].ConditionID)
+	}
+}
+
+// TestIntegration_Markets_Pagination tests pagination on /markets endpoint.
+func TestIntegration_Markets_Pagination(t *testing.T) {
+	c := getTestClient(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultTimeout)
+	defer cancel()
+
+	// First page
+	page1, err := c.Markets(ctx, "")
+	if err != nil {
+		t.Fatalf("Markets (page 1) failed: %v", err)
+	}
+
+	if page1.NextCursor == "" {
+		t.Skip("No next cursor, cannot test pagination")
+	}
+
+	// Second page
+	page2, err := c.Markets(ctx, page1.NextCursor)
+	if err != nil {
+		t.Fatalf("Markets (page 2) failed: %v", err)
+	}
+
+	t.Logf("Page 1: Count=%d, Page 2: Count=%d", page1.Count, page2.Count)
+
+	// Ensure we got different data (if both pages have data)
+	if len(page1.Data) > 0 && len(page2.Data) > 0 {
+		if page1.Data[0].ConditionID != nil && page2.Data[0].ConditionID != nil {
+			if *page1.Data[0].ConditionID == *page2.Data[0].ConditionID {
+				t.Error("Page 1 and Page 2 returned the same first market")
+			}
+		}
+	}
+}
+
+// TestIntegration_Market tests the /markets/{condition_id} endpoint against the live API.
+func TestIntegration_Market(t *testing.T) {
+	c := getTestClient(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultTimeout)
+	defer cancel()
+
+	// First, get a valid condition_id from the markets list
+	markets, err := c.Markets(ctx, "")
+	if err != nil {
+		t.Fatalf("Markets failed: %v", err)
+	}
+
+	if len(markets.Data) == 0 {
+		t.Skip("No markets available to test Market endpoint")
+	}
+
+	// Find a market with a valid condition_id
+	var conditionID string
+	for _, m := range markets.Data {
+		if m.ConditionID != nil && *m.ConditionID != "" {
+			conditionID = *m.ConditionID
+			break
+		}
+	}
+
+	if conditionID == "" {
+		t.Skip("No market with condition_id found")
+	}
+
+	t.Logf("Testing Market with condition_id: %s", conditionID)
+
+	req := &types.MarketRequest{ConditionID: conditionID}
+	resp, err := c.Market(ctx, req)
+	if err != nil {
+		t.Fatalf("Market failed: %v", err)
+	}
+
+	t.Logf("Market response: Question=%s, Active=%v", resp.Question, resp.Active)
+
+	if resp.ConditionID == nil || *resp.ConditionID != conditionID {
+		t.Errorf("Expected condition_id %s, got %v", conditionID, resp.ConditionID)
+	}
+}
+
+// TestIntegration_SimplifiedMarkets tests the /simplified-markets endpoint against the live API.
+func TestIntegration_SimplifiedMarkets(t *testing.T) {
+	c := getTestClient(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultTimeout)
+	defer cancel()
+
+	resp, err := c.SimplifiedMarkets(ctx, "")
+	if err != nil {
+		t.Fatalf("SimplifiedMarkets failed: %v", err)
+	}
+
+	t.Logf("SimplifiedMarkets response: Count=%d, Limit=%d", resp.Count, resp.Limit)
+
+	if resp.Count > 0 && len(resp.Data) > 0 {
+		t.Logf("First simplified market condition_id: %v", resp.Data[0].ConditionID)
+	}
+}
+
+// TestIntegration_SamplingMarkets tests the /sampling-markets endpoint against the live API.
+func TestIntegration_SamplingMarkets(t *testing.T) {
+	c := getTestClient(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultTimeout)
+	defer cancel()
+
+	resp, err := c.SamplingMarkets(ctx, "")
+	if err != nil {
+		// Response body too large is expected for this endpoint
+		if strings.Contains(err.Error(), "response body too large") {
+			t.Skip("SamplingMarkets response too large for default transport settings")
+		}
+		t.Fatalf("SamplingMarkets failed: %v", err)
+	}
+
+	t.Logf("SamplingMarkets response: Count=%d, Limit=%d", resp.Count, resp.Limit)
+
+	if resp.Count > 0 && len(resp.Data) > 0 {
+		t.Logf("First sampling market condition_id: %v", resp.Data[0].ConditionID)
+	}
+}
+
+// TestIntegration_SamplingSimplifiedMarkets tests the /sampling-simplified-markets endpoint.
+func TestIntegration_SamplingSimplifiedMarkets(t *testing.T) {
+	c := getTestClient(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultTimeout)
+	defer cancel()
+
+	resp, err := c.SamplingSimplifiedMarkets(ctx, "")
+	if err != nil {
+		t.Fatalf("SamplingSimplifiedMarkets failed: %v", err)
+	}
+
+	t.Logf("SamplingSimplifiedMarkets response: Count=%d, Limit=%d", resp.Count, resp.Limit)
+
+	if resp.Count > 0 && len(resp.Data) > 0 {
+		t.Logf("First sampling simplified market condition_id: %v", resp.Data[0].ConditionID)
+	}
+}
+
+// TestIntegration_OrderBook tests the /book endpoint against the live API.
+// Uses Gamma API to get valid token IDs.
+func TestIntegration_OrderBook(t *testing.T) {
+	c := getTestClient(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultTimeout)
+	defer cancel()
+
+	// Fetch token_id from Gamma API
+	tokenID, err := fetchTokenIDFromGamma(ctx)
+	if err != nil {
+		t.Skipf("Could not fetch token_id from Gamma API: %v", err)
+	}
+
+	t.Logf("Testing OrderBook with token_id: %s", tokenID)
+
+	req := &types.OrderBookSummaryRequest{
+		TokenId: tokenID,
+		Side:    types.SideBuy,
+	}
+
+	resp, err := c.OrderBook(ctx, req)
+	if err != nil {
+		t.Fatalf("OrderBook failed: %v", err)
+	}
+
+	t.Logf("OrderBook response: Market=%s, AssetID=%s, Bids=%d, Asks=%d",
+		resp.Market, resp.AssetID, len(resp.Bids), len(resp.Asks))
+}
+
+// TestIntegration_OrderBooks tests the /books endpoint against the live API.
+// Uses Gamma API to get valid token IDs.
+func TestIntegration_OrderBooks(t *testing.T) {
+	c := getTestClient(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultTimeout)
+	defer cancel()
+
+	// Fetch token_id from Gamma API
+	tokenID, err := fetchTokenIDFromGamma(ctx)
+	if err != nil {
+		t.Skipf("Could not fetch token_id from Gamma API: %v", err)
+	}
+
+	t.Logf("Testing OrderBooks with token_id: %s", tokenID)
+
+	req := []types.OrderBookSummaryRequest{
+		{TokenId: tokenID},
+	}
+
+	resp, err := c.OrderBooks(ctx, req)
+	if err != nil {
+		t.Fatalf("OrderBooks failed: %v", err)
+	}
+
+	if len(resp) == 0 {
+		t.Fatal("Expected at least one order book response")
+	}
+
+	t.Logf("OrderBooks response: count=%d, first market=%s", len(resp), resp[0].Market)
+}
+
+// GammaMarket represents a market from the Gamma API.
+type GammaMarket struct {
+	ClobTokenIds string `json:"clobTokenIds"`
+}
+
+// fetchTokenIDFromGamma fetches a valid token_id from the Gamma API.
+func fetchTokenIDFromGamma(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		"https://gamma-api.polymarket.com/markets?limit=5&active=true&closed=false", nil)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("gamma API returned status %d", resp.StatusCode)
+	}
+
+	var markets []GammaMarket
+	if err := json.NewDecoder(resp.Body).Decode(&markets); err != nil {
+		return "", err
+	}
+
+	if len(markets) == 0 {
+		return "", fmt.Errorf("no markets found")
+	}
+
+	// Parse clobTokenIds JSON array (it's a JSON string)
+	for _, m := range markets {
+		if m.ClobTokenIds == "" || m.ClobTokenIds == "null" {
+			continue
+		}
+		var tokenIds []string
+		if err := json.Unmarshal([]byte(m.ClobTokenIds), &tokenIds); err != nil {
+			continue
+		}
+		if len(tokenIds) > 0 && tokenIds[0] != "" {
+			return tokenIds[0], nil
+		}
+	}
+
+	return "", fmt.Errorf("no valid token_id found in markets")
+}
+
+// TestIntegration_AllEndpointsReachable runs a smoke test to verify all endpoints are reachable.
+func TestIntegration_AllEndpointsReachable(t *testing.T) {
+	c := getTestClient(t)
+
+	tests := []struct {
+		name          string
+		fn            func(context.Context) error
+		skipBodyLarge bool // if true, skip on "response body too large" errors
+	}{
+		// Ping is excluded - Polymarket doesn't have this endpoint
+		{
+			name: "Markets",
+			fn: func(ctx context.Context) error {
+				_, err := c.Markets(ctx, "")
+				return err
+			},
+		},
+		{
+			name: "SimplifiedMarkets",
+			fn: func(ctx context.Context) error {
+				_, err := c.SimplifiedMarkets(ctx, "")
+				return err
+			},
+		},
+		{
+			name:          "SamplingMarkets",
+			skipBodyLarge: true,
+			fn: func(ctx context.Context) error {
+				_, err := c.SamplingMarkets(ctx, "")
+				return err
+			},
+		},
+		{
+			name: "SamplingSimplifiedMarkets",
+			fn: func(ctx context.Context) error {
+				_, err := c.SamplingSimplifiedMarkets(ctx, "")
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), DefaultTimeout)
+			defer cancel()
+
+			err := tt.fn(ctx)
+			if err != nil {
+				if tt.skipBodyLarge && strings.Contains(err.Error(), "response body too large") {
+					t.Skipf("%s: response body too large (expected)", tt.name)
+				}
+				t.Errorf("%s endpoint failed: %v", tt.name, err)
+			} else {
+				t.Logf("%s endpoint: OK", tt.name)
+			}
+		})
+	}
+}

--- a/clob/public_client_integration_test.go
+++ b/clob/public_client_integration_test.go
@@ -786,7 +786,7 @@ func TestIntegration_GetPricesHistory(t *testing.T) {
 
 		// Test branch 2: Custom Range
 		mid := (first.Time + last.Time) / 2
-		start := mid - 120 
+		start := mid - 120
 		end := mid + 120
 
 		t.Logf("Testing GetPricesHistory with custom range: %d - %d", start, end)

--- a/clob/public_client_price_endpoints_test.go
+++ b/clob/public_client_price_endpoints_test.go
@@ -1,0 +1,346 @@
+package clob
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"github.com/star-gazer111/poly-go-clob-client/types"
+)
+
+func setupTestServer(t *testing.T, handler http.HandlerFunc) (*httptest.Server, *PublicClient) {
+	srv := httptest.NewServer(handler)
+	c, err := NewPublicClient(srv.URL)
+	if err != nil {
+		t.Fatalf("NewPublicClient err: %v", err)
+	}
+	return srv, c
+}
+
+func TestMidpoint_Happy(t *testing.T) {
+	expectedMid := decimal.NewFromFloat(0.5)
+	srv, c := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/midpoint" {
+			t.Errorf("Expected /midpoint, got %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("token_id") != "123" {
+			t.Errorf("Expected token_id=123, got %s", r.URL.Query().Get("token_id"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		resp := types.MidpointResponse{Mid: expectedMid}
+		json.NewEncoder(w).Encode(resp)
+	})
+	defer srv.Close()
+
+	resp, err := c.Midpoint(context.Background(), &types.MidpointRequest{TokenId: "123"})
+	if err != nil {
+		t.Fatalf("Midpoint err: %v", err)
+	}
+	if !resp.Mid.Equal(expectedMid) {
+		t.Errorf("Expected %v, got %v", expectedMid, resp.Mid)
+	}
+}
+
+func TestMidpoint_Errors(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		kind       types.Kind
+	}{
+		{"429", 429, types.KindStatus},
+		{"500", 500, types.KindStatus},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv, c := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.statusCode)
+			})
+			defer srv.Close()
+
+			_, err := c.Midpoint(context.Background(), &types.MidpointRequest{TokenId: "123"})
+			if err == nil {
+				t.Fatal("Expected error")
+			}
+			var te *types.Error
+			if errors.As(err, &te) {
+				if te.Kind() != tt.kind {
+					t.Errorf("Expected kind %v, got %v", tt.kind, te.Kind())
+				}
+			}
+		})
+	}
+}
+
+func TestMidpoints_Happy(t *testing.T) {
+	srv, c := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/midpoints" {
+			t.Errorf("Expected /midpoints, got %s", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Errorf("Expected POST, got %s", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		// Correct response strictly is map directly
+		m := map[string]decimal.Decimal{
+			"123": decimal.NewFromFloat(0.5),
+		}
+		json.NewEncoder(w).Encode(m)
+	})
+	defer srv.Close()
+
+	req := []types.MidpointRequest{{TokenId: "123"}}
+	resp, err := c.Midpoints(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Midpoints err: %v", err)
+	}
+	if val, ok := resp["123"]; !ok || !val.Equal(decimal.NewFromFloat(0.5)) {
+		t.Errorf("Expected 123:0.5, got %v", resp)
+	}
+}
+
+func TestMidpoints_Errors(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+	}{
+		{"429", 429},
+		{"500", 500},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv, c := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.statusCode)
+			})
+			defer srv.Close()
+			_, err := c.Midpoints(context.Background(), []types.MidpointRequest{{TokenId: "123"}})
+			if err == nil {
+				t.Fatal("Expected error")
+			}
+		})
+	}
+}
+
+func TestGetPrice_Happy(t *testing.T) {
+	expectedPrice := decimal.NewFromFloat(0.4)
+	srv, c := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/price" {
+			t.Errorf("Expected /price, got %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("token_id") != "123" {
+			t.Errorf("Expected token_id=123")
+		}
+		if r.URL.Query().Get("side") != "BUY" {
+			t.Errorf("Expected side=BUY")
+		}
+		json.NewEncoder(w).Encode(types.PriceResponse{Price: expectedPrice})
+	})
+	defer srv.Close()
+
+	resp, err := c.GetPrice(context.Background(), types.PriceRequest{TokenId: "123", Side: "BUY"})
+	if err != nil {
+		t.Fatalf("GetPrice err: %v", err)
+	}
+	if !resp.Price.Equal(expectedPrice) {
+		t.Errorf("Expected %v, got %v", expectedPrice, resp.Price)
+	}
+}
+
+func TestGetPrice_Errors(t *testing.T) {
+	tests := []struct{ code int }{{429}, {500}}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%d", tt.code), func(t *testing.T) {
+			srv, c := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(tt.code) })
+			defer srv.Close()
+			_, err := c.GetPrice(context.Background(), types.PriceRequest{TokenId: "123", Side: "BUY"})
+			if err == nil {
+				t.Fatal("Expected error")
+			}
+		})
+	}
+}
+
+func TestGetPrices_Happy(t *testing.T) {
+	srv, c := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/prices" {
+			t.Errorf("Expected /prices")
+		}
+		m := map[string]map[string]decimal.Decimal{
+			"123": {"BUY": decimal.NewFromFloat(0.4)},
+		}
+		json.NewEncoder(w).Encode(m)
+	})
+	defer srv.Close()
+
+	req := []types.PriceRequest{{TokenId: "123", Side: "BUY"}}
+	resp, err := c.GetPrices(context.Background(), req)
+	if err != nil {
+		t.Fatalf("GetPrices err: %v", err)
+	}
+	if val := resp["123"]["BUY"]; !val.Equal(decimal.NewFromFloat(0.4)) {
+		t.Errorf("Expected 0.4, got %v", val)
+	}
+}
+
+func TestGetPrices_Errors(t *testing.T) {
+	tests := []struct{ code int }{{429}, {500}}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%d", tt.code), func(t *testing.T) {
+			srv, c := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(tt.code) })
+			defer srv.Close()
+			_, err := c.GetPrices(context.Background(), nil)
+			if err == nil {
+				t.Fatal("Expected error")
+			}
+		})
+	}
+}
+
+func TestGetSpread_Happy(t *testing.T) {
+	expectedSpread := decimal.NewFromFloat(0.01)
+	srv, c := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/spread" {
+			t.Errorf("Expected /spread")
+		}
+		if r.URL.Query().Get("token_id") != "123" {
+			t.Errorf("Expected token_id=123")
+		}
+		json.NewEncoder(w).Encode(types.SpreadResponse{Spread: expectedSpread})
+	})
+	defer srv.Close()
+
+	resp, err := c.GetSpread(context.Background(), types.SpreadRequest{TokenId: "123"})
+	if err != nil {
+		t.Fatalf("GetSpread err: %v", err)
+	}
+	if !resp.Spread.Equal(expectedSpread) {
+		t.Errorf("Expected %v, got %v", expectedSpread, resp.Spread)
+	}
+}
+
+func TestGetSpread_Errors(t *testing.T) {
+	tests := []struct{ code int }{{429}, {500}}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%d", tt.code), func(t *testing.T) {
+			srv, c := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(tt.code) })
+			defer srv.Close()
+			_, err := c.GetSpread(context.Background(), types.SpreadRequest{TokenId: "123"})
+			if err == nil {
+				t.Fatal("Expected error")
+			}
+		})
+	}
+}
+
+func TestGetSpreads_Happy(t *testing.T) {
+	srv, c := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/spreads" {
+			t.Errorf("Expected /spreads")
+		}
+		m := map[string]decimal.Decimal{
+			"123": decimal.NewFromFloat(0.01),
+		}
+		json.NewEncoder(w).Encode(m)
+	})
+	defer srv.Close()
+
+	resp, err := c.GetSpreads(context.Background(), []types.SpreadRequest{{TokenId: "123"}})
+	if err != nil {
+		t.Fatalf("GetSpreads err: %v", err)
+	}
+	if val := resp["123"]; !val.Equal(decimal.NewFromFloat(0.01)) {
+		t.Errorf("Expected 0.01, got %v", val)
+	}
+}
+
+func TestGetSpreads_Errors(t *testing.T) {
+	tests := []struct{ code int }{{429}, {500}}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%d", tt.code), func(t *testing.T) {
+			srv, c := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(tt.code) })
+			defer srv.Close()
+			_, err := c.GetSpreads(context.Background(), []types.SpreadRequest{{TokenId: "123"}})
+			if err == nil {
+				t.Fatal("Expected error")
+			}
+		})
+	}
+}
+
+func TestGetPricesHistory_Happy(t *testing.T) {
+	srv, c := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/prices-history" {
+			t.Errorf("Expected /prices-history")
+		}
+		if r.URL.Query().Get("market") != "123" {
+			t.Errorf("Expected market=123")
+		}
+		if r.URL.Query().Get("interval") != "1m" {
+			t.Errorf("Expected interval=1m")
+		}
+
+		item := types.PriceHistoryItem{
+			Time:  time.Now().Unix(),
+			Price: decimal.NewFromFloat(0.5),
+		}
+		resp := types.PricesHistoryResponse{
+			History: []types.PriceHistoryItem{item},
+		}
+		json.NewEncoder(w).Encode(resp)
+	})
+	defer srv.Close()
+
+	req := types.PricesHistoryRequest{
+		Market:   "123",
+		Interval: types.Interval1m,
+	}
+	resp, err := c.GetPricesHistory(context.Background(), req)
+	if err != nil {
+		t.Fatalf("GetPricesHistory err: %v", err)
+	}
+	if len(resp.History) != 1 {
+		t.Errorf("Expected 1 history item, got %d", len(resp.History))
+	}
+}
+
+func TestGetPricesHistory_Validation(t *testing.T) {
+	// Not an HTTP test, but validation logic test
+	c, _ := NewPublicClient("http://example.com")
+
+	// Default: Fail (must provide interval or range)
+	_, err := c.GetPricesHistory(context.Background(), types.PricesHistoryRequest{Market: "123"})
+	if err == nil {
+		t.Error("Expected error for missing Interval/Range")
+	}
+
+	// Double: Fail (cannot provide both)
+	start := int64(100)
+	_, err = c.GetPricesHistory(context.Background(), types.PricesHistoryRequest{
+		Market:   "123",
+		Interval: types.Interval1m,
+		StartTs:  &start,
+	})
+	if err == nil {
+		t.Error("Expected error for both Interval and Range")
+	}
+}
+
+func TestGetPricesHistory_Errors(t *testing.T) {
+	tests := []struct{ code int }{{429}, {500}}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%d", tt.code), func(t *testing.T) {
+			srv, c := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(tt.code) })
+			defer srv.Close()
+			_, err := c.GetPricesHistory(context.Background(), types.PricesHistoryRequest{Market: "123", Interval: types.Interval1m})
+			if err == nil {
+				t.Fatal("Expected error")
+			}
+		})
+	}
+}

--- a/clob/public_client_price_endpoints_test.go
+++ b/clob/public_client_price_endpoints_test.go
@@ -34,7 +34,7 @@ func TestMidpoint_Happy(t *testing.T) {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		resp := types.MidpointResponse{Mid: expectedMid}
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	})
 	defer srv.Close()
 
@@ -91,7 +91,7 @@ func TestMidpoints_Happy(t *testing.T) {
 		m := map[string]decimal.Decimal{
 			"123": decimal.NewFromFloat(0.5),
 		}
-		json.NewEncoder(w).Encode(m)
+		_ = json.NewEncoder(w).Encode(m)
 	})
 	defer srv.Close()
 
@@ -139,7 +139,7 @@ func TestGetPrice_Happy(t *testing.T) {
 		if r.URL.Query().Get("side") != "BUY" {
 			t.Errorf("Expected side=BUY")
 		}
-		json.NewEncoder(w).Encode(types.PriceResponse{Price: expectedPrice})
+		_ = json.NewEncoder(w).Encode(types.PriceResponse{Price: expectedPrice})
 	})
 	defer srv.Close()
 
@@ -174,7 +174,7 @@ func TestGetPrices_Happy(t *testing.T) {
 		m := map[string]map[string]decimal.Decimal{
 			"123": {"BUY": decimal.NewFromFloat(0.4)},
 		}
-		json.NewEncoder(w).Encode(m)
+		_ = json.NewEncoder(w).Encode(m)
 	})
 	defer srv.Close()
 
@@ -211,7 +211,7 @@ func TestGetSpread_Happy(t *testing.T) {
 		if r.URL.Query().Get("token_id") != "123" {
 			t.Errorf("Expected token_id=123")
 		}
-		json.NewEncoder(w).Encode(types.SpreadResponse{Spread: expectedSpread})
+		_ = json.NewEncoder(w).Encode(types.SpreadResponse{Spread: expectedSpread})
 	})
 	defer srv.Close()
 
@@ -246,7 +246,7 @@ func TestGetSpreads_Happy(t *testing.T) {
 		m := map[string]decimal.Decimal{
 			"123": decimal.NewFromFloat(0.01),
 		}
-		json.NewEncoder(w).Encode(m)
+		_ = json.NewEncoder(w).Encode(m)
 	})
 	defer srv.Close()
 
@@ -292,7 +292,7 @@ func TestGetPricesHistory_Happy(t *testing.T) {
 		resp := types.PricesHistoryResponse{
 			History: []types.PriceHistoryItem{item},
 		}
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	})
 	defer srv.Close()
 

--- a/clob/public_client_test.go
+++ b/clob/public_client_test.go
@@ -1,0 +1,98 @@
+package clob
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/star-gazer111/poly-go-clob-client/types"
+)
+
+func TestNewPublicClient_BaseURLValidation(t *testing.T) {
+	_, err := NewPublicClient("")
+	if err == nil {
+		t.Fatal("expected error for empty baseURL")
+	}
+	var te *types.Error
+	if !errors.As(err, &te) || te.Kind() != types.KindValidation {
+		t.Fatalf("expected KindValidation error, got: %T %v", err, err)
+	}
+
+	_, err = NewPublicClient("not a url")
+	if err == nil {
+		t.Fatal("expected error for invalid url")
+	}
+	if !errors.As(err, &te) || te.Kind() != types.KindValidation {
+		t.Fatalf("expected KindValidation error, got: %T %v", err, err)
+	}
+}
+
+func TestPublicClient_Ping_OK_JSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/ping" {
+			t.Fatalf("expected /ping, got %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"ok":true,"message":"pong"}`))
+	}))
+	defer srv.Close()
+
+	c, err := NewPublicClient(srv.URL) // http ok for tests
+	if err != nil {
+		t.Fatalf("NewPublicClient err: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	out, err := c.Ping(ctx)
+	if err != nil {
+		t.Fatalf("Ping err: %v", err)
+	}
+	if out == nil || !out.OK || out.Message != "pong" {
+		t.Fatalf("unexpected ping response: %+v", out)
+	}
+}
+
+func TestPublicClient_Ping_Non2xx_ReturnsTypedError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(429)
+		_, _ = w.Write([]byte(`rate limited`))
+	}))
+	defer srv.Close()
+
+	c, err := NewPublicClient(srv.URL)
+	if err != nil {
+		t.Fatalf("NewPublicClient err: %v", err)
+	}
+
+	_, err = c.Ping(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	// must be a typed Status error
+	var st *types.Status
+	if !errors.As(err, &st) {
+		t.Fatalf("expected errors.As to find *types.Status, got %T %v", err, err)
+	}
+	if st.StatusCode != 429 {
+		t.Fatalf("expected 429, got %d", st.StatusCode)
+	}
+	if st.Path != "/ping" {
+		t.Fatalf("expected path /ping, got %s", st.Path)
+	}
+
+	// top level kind should be KindStatus
+	var top *types.Error
+	if !errors.As(err, &top) {
+		t.Fatalf("expected errors.As to find *types.Error, got %T %v", err, err)
+	}
+	if top.Kind() != types.KindStatus {
+		t.Fatalf("expected kind %s, got %s", types.KindStatus, top.Kind())
+	}
+}

--- a/clob/public_client_test.go
+++ b/clob/public_client_test.go
@@ -83,8 +83,8 @@ func TestPublicClient_Ping_Non2xx_ReturnsTypedError(t *testing.T) {
 	if st.StatusCode != 429 {
 		t.Fatalf("expected 429, got %d", st.StatusCode)
 	}
-	if st.Path != "/ping" {
-		t.Fatalf("expected path /ping, got %s", st.Path)
+	if st.Path != "/" {
+		t.Fatalf("expected path /, got %s", st.Path)
 	}
 
 	// top level kind should be KindStatus

--- a/clob/public_client_test.go
+++ b/clob/public_client_test.go
@@ -32,12 +32,12 @@ func TestNewPublicClient_BaseURLValidation(t *testing.T) {
 
 func TestPublicClient_Ping_OK_JSON(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/ping" {
-			t.Fatalf("expected /ping, got %s", r.URL.Path)
+		if r.URL.Path != "/" {
+			t.Fatalf("expected /, got %s", r.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
-		_, _ = w.Write([]byte(`{"ok":true,"message":"pong"}`))
+		_, _ = w.Write([]byte(`{"ok":true,"message":"OK"}`))
 	}))
 	defer srv.Close()
 
@@ -53,7 +53,7 @@ func TestPublicClient_Ping_OK_JSON(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Ping err: %v", err)
 	}
-	if out == nil || !out.OK || out.Message != "pong" {
+	if out == nil || !out.OK || out.Message != "OK" {
 		t.Fatalf("unexpected ping response: %+v", out)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.22
 
 require (
 	github.com/ethereum/go-ethereum v1.14.12
+	github.com/shopspring/decimal v1.4.0
 	golang.org/x/time v0.6.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/ethereum/go-ethereum v1.14.12 h1:8hl57x77HSUo+cXExrURjU/w1VhL+ShCTJrT
 github.com/ethereum/go-ethereum v1.14.12/go.mod h1:RAC2gVMWJ6FkxSPESfbshrcKpIokgQKsVKmAuqdekDY=
 github.com/holiman/uint256 v1.3.1 h1:JfTzmih28bittyHM8z360dCjIA9dbPIBlcTI6lmctQs=
 github.com/holiman/uint256 v1.3.1/go.mod h1:EOMSn4q6Nyt9P6efbI3bueV4e1b3dGlUCXeiRV4ng7E=
+github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
+github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 golang.org/x/crypto v0.22.0 h1:g1v0xeRhjcugydODzvb3mEM9SQ0HGp9s/nh3COQ/C30=
 golang.org/x/crypto v0.22.0/go.mod h1:vr6Su+7cTlO45qkww3VDJlzDn0ctJvRgYbC2NvXHt+M=
 golang.org/x/sys v0.22.0 h1:RI27ohtqKCnwULzJLqkv897zojh5/DwS/ENaMzUOaWI=

--- a/internal/redaction/redaction.go
+++ b/internal/redaction/redaction.go
@@ -12,14 +12,15 @@ const DefaultRedaction = "***"
 // It preserves a small prefix/suffix to help debugging without leaking secrets
 //
 // Some simple examples to understand:
-//   "abcd" -> "***"
-//   "abcdefg" -> "abc***efg"
+//
+//	"abcd" -> "***"
+//	"abcdefg" -> "abc***efg"
 func Redact(s string) string {
 	s = strings.TrimSpace(s)
 	if s == "" {
 		return ""
 	}
-	// Keeping the behavior conservative for short secrets 
+	// Keeping the behavior conservative for short secrets
 	if len(s) <= 8 {
 		return DefaultRedaction
 	}

--- a/internal/transport/retry.go
+++ b/internal/transport/retry.go
@@ -91,8 +91,9 @@ func bodyPreview(b []byte) string {
 
 // doJSONWithRetry performs the request via Transport.Do and returns the raw response body.
 // On non-2xx it returns a typed error compatible with:
-//   errors.As(err, *types.Status)
-//   errors.As(err, *types.Error) with KindStatus
+//
+//	errors.As(err, *types.Status)
+//	errors.As(err, *types.Error) with KindStatus
 func doJSONWithRetry(ctx context.Context, t *Transport, req *http.Request) ([]byte, error) {
 	p := t.policy.Retry
 	attempts := 0

--- a/internal/transport/retry.go
+++ b/internal/transport/retry.go
@@ -122,7 +122,7 @@ func doJSONWithRetry(ctx context.Context, t *Transport, req *http.Request) ([]by
 
 		// IMPORTANT: close per attempt; do NOT defer in loop.
 		b, rerr := io.ReadAll(resp.Body)
-		resp.Body.Close()
+		_ = resp.Body.Close()
 
 		if rerr != nil {
 			return nil, types.WithSource(types.KindInternal, rerr)

--- a/types/errors.go
+++ b/types/errors.go
@@ -91,8 +91,8 @@ func (s *Synchronization) Error() string {
 
 // in rust chain_id is ChainId but in go i am keeping it uint64 for now - confirm later todo
 type MissingContractConfig struct {
-	ChainID  uint64
-	NegRisk  bool
+	ChainID uint64
+	NegRisk bool
 }
 
 func (m *MissingContractConfig) Error() string {

--- a/types/public.go
+++ b/types/public.go
@@ -11,3 +11,15 @@ const (
 	SideSell    Side = 1
 	SideUnknown Side = 255
 )
+
+// Interval represents time intervals for price history.
+type Interval string
+
+const (
+	Interval1m  Interval = "1m"
+	Interval1h  Interval = "1h"
+	Interval6h  Interval = "6h"
+	Interval1d  Interval = "1d"
+	Interval1w  Interval = "1w"
+	IntervalMax Interval = "max"
+)

--- a/types/public.go
+++ b/types/public.go
@@ -2,3 +2,12 @@ package types
 
 // Common/shared types go here as the SDK grows.
 // Keep this file minimal for v0.1.
+
+// Side represents the order side (buy or sell).
+type Side int
+
+const (
+	SideBuy     Side = 0
+	SideSell    Side = 1
+	SideUnknown Side = 255
+)

--- a/types/request.go
+++ b/types/request.go
@@ -13,3 +13,8 @@ type MarketRequest struct {
 type LastTradePriceRequest struct {
 	TokenId string `json:"token_id"`
 }
+
+type GetMarketTradesEventsRequest struct {
+	ConditionID string `json:"condition_id"`
+	NextCursor  string `json:"next_cursor,omitempty"`
+}

--- a/types/request.go
+++ b/types/request.go
@@ -1,0 +1,6 @@
+package types
+
+type OrderBookSummaryRequest struct {
+	TokenId uint `json:"token_id"`
+	Side    Side `json:"side"`
+}

--- a/types/request.go
+++ b/types/request.go
@@ -18,3 +18,24 @@ type GetMarketTradesEventsRequest struct {
 	ConditionID string `json:"condition_id"`
 	NextCursor  string `json:"next_cursor,omitempty"`
 }
+
+type MidpointRequest struct {
+	TokenId string `json:"token_id"`
+}
+
+type PriceRequest struct {
+	TokenId string `json:"token_id"`
+	Side    string `json:"side"` // "BUY" or "SELL"
+}
+type SpreadRequest struct {
+	TokenId string `json:"token_id"`
+	Side    *Side  `json:"side,omitempty"`
+}
+
+type PricesHistoryRequest struct {
+	Market   string   `json:"market"`
+	Interval Interval `json:"interval,omitempty"`
+	StartTs  *int64   `json:"startTs,omitempty"`
+	EndTs    *int64   `json:"endTs,omitempty"`
+	Fidelity *uint32  `json:"fidelity,omitempty"`
+}

--- a/types/request.go
+++ b/types/request.go
@@ -1,8 +1,8 @@
 package types
 
 type OrderBookSummaryRequest struct {
-	TokenId uint `json:"token_id"`
-	Side    Side `json:"side"`
+	TokenId string `json:"token_id"`
+	Side    Side   `json:"side,omitempty"`
 }
 
 // MarketRequest represents a request to fetch a market by condition ID.

--- a/types/request.go
+++ b/types/request.go
@@ -9,3 +9,7 @@ type OrderBookSummaryRequest struct {
 type MarketRequest struct {
 	ConditionID string `json:"condition_id"`
 }
+
+type LastTradePriceRequest struct {
+	TokenId string `json:"token_id"`
+}

--- a/types/request.go
+++ b/types/request.go
@@ -4,3 +4,8 @@ type OrderBookSummaryRequest struct {
 	TokenId uint `json:"token_id"`
 	Side    Side `json:"side"`
 }
+
+// MarketRequest represents a request to fetch a market by condition ID.
+type MarketRequest struct {
+	ConditionID string `json:"condition_id"`
+}

--- a/types/response.go
+++ b/types/response.go
@@ -119,5 +119,5 @@ type OrderBookSummaryResponse struct {
 
 type LastTradePriceResponse struct {
 	Price json.Number `json:"price"`
-	Side  Side        `json:"side,omitempty"`
+	Side  string      `json:"side,omitempty"`
 }

--- a/types/response.go
+++ b/types/response.go
@@ -1,0 +1,23 @@
+package types
+
+import "time"
+
+// OrderSummary represents a single price level in the order book.
+type OrderSummary struct {
+	Price float64 `json:"price"`
+	Size  float64 `json:"size"`
+}
+
+// OrderBookSummaryResponse represents the response from the order book summary endpoint.
+type OrderBookSummaryResponse struct {
+	Market         string         `json:"market"`
+	AssetID        string         `json:"asset_id"`
+	Timestamp      time.Time      `json:"timestamp"`
+	Hash           *string        `json:"hash,omitempty"`
+	Bids           []OrderSummary `json:"bids"`
+	Asks           []OrderSummary `json:"asks"`
+	MinOrderSize   float64        `json:"min_order_size"`
+	NegRisk        bool           `json:"neg_risk"`
+	TickSize       float64        `json:"tick_size"`
+	LastTradePrice *float64       `json:"last_trade_price,omitempty"`
+}

--- a/types/response.go
+++ b/types/response.go
@@ -1,6 +1,69 @@
 package types
 
-import "time"
+import (
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+// Token represents a market token.
+type Token struct {
+	TokenID string `json:"token_id"`
+	Outcome string `json:"outcome"`
+	Price   string `json:"price,omitempty"`
+	Winner  bool   `json:"winner"`
+}
+
+// Rewards represents market rewards configuration.
+type Rewards struct {
+	Rates     []RewardRate `json:"rates"`
+	MinSize   string       `json:"min_size"`
+	MaxSpread string       `json:"max_spread"`
+}
+
+// RewardRate represents a reward rate entry.
+type RewardRate struct {
+	AssetAddress string `json:"asset_address"`
+	RewardsDaily string `json:"rewards_daily"`
+}
+
+// MarketResponse represents a market from the CLOB API.
+type MarketResponse struct {
+	EnableOrderBook         bool            `json:"enable_order_book"`
+	Active                  bool            `json:"active"`
+	Closed                  bool            `json:"closed"`
+	Archived                bool            `json:"archived"`
+	AcceptingOrders         bool            `json:"accepting_orders"`
+	AcceptingOrderTimestamp *time.Time      `json:"accepting_order_timestamp,omitempty"`
+	MinimumOrderSize        decimal.Decimal `json:"minimum_order_size"`
+	MinimumTickSize         decimal.Decimal `json:"minimum_tick_size"`
+	// ConditionID is the market condition ID (unique market identifier).
+	ConditionID *string `json:"condition_id,omitempty"`
+	// QuestionID is the CTF question ID.
+	QuestionID    *string    `json:"question_id,omitempty"`
+	Question      string     `json:"question"`
+	Description   string     `json:"description"`
+	MarketSlug    string     `json:"market_slug"`
+	EndDateISO    *time.Time `json:"end_date_iso,omitempty"`
+	GameStartTime *time.Time `json:"game_start_time,omitempty"`
+	SecondsDelay  uint64     `json:"seconds_delay"`
+	// FPMM is the Fixed Product Market Maker contract address.
+	FPMM                 *string         `json:"fpmm,omitempty"`
+	MakerBaseFee         decimal.Decimal `json:"maker_base_fee"`
+	TakerBaseFee         decimal.Decimal `json:"taker_base_fee"`
+	NotificationsEnabled bool            `json:"notifications_enabled"`
+	NegRisk              bool            `json:"neg_risk"`
+	// NegRiskMarketID is the negative risk market ID (empty string if not a neg risk market).
+	NegRiskMarketID *string `json:"neg_risk_market_id,omitempty"`
+	// NegRiskRequestID is the negative risk request ID (empty string if not a neg risk market).
+	NegRiskRequestID *string  `json:"neg_risk_request_id,omitempty"`
+	Icon             string   `json:"icon"`
+	Image            string   `json:"image"`
+	Rewards          Rewards  `json:"rewards"`
+	Is5050Outcome    bool     `json:"is_50_50_outcome"`
+	Tokens           []Token  `json:"tokens"`
+	Tags             []string `json:"tags"`
+}
 
 // OrderSummary represents a single price level in the order book.
 type OrderSummary struct {

--- a/types/response.go
+++ b/types/response.go
@@ -65,6 +65,17 @@ type MarketResponse struct {
 	Tags             []string `json:"tags"`
 }
 
+// MarketsPage represents a paginated list of markets.
+type MarketsPage struct {
+	Data []MarketResponse `json:"data"`
+	// NextCursor is the continuation token to supply to the API for the next page.
+	NextCursor string `json:"next_cursor"`
+	// Limit is the maximum length of Data.
+	Limit uint64 `json:"limit"`
+	// Count is the actual length of Data.
+	Count uint64 `json:"count"`
+}
+
 // OrderSummary represents a single price level in the order book.
 type OrderSummary struct {
 	Price float64 `json:"price"`

--- a/types/response.go
+++ b/types/response.go
@@ -121,3 +121,16 @@ type LastTradePriceResponse struct {
 	Price json.Number `json:"price"`
 	Side  string      `json:"side,omitempty"`
 }
+
+type TradeEvent struct {
+	AssetID   string      `json:"asset_id"`
+	Price     json.Number `json:"price"`
+	Size      json.Number `json:"size"`
+	Side      string      `json:"side"`
+	Timestamp json.Number `json:"timestamp"`
+}
+
+type MarketTradesEventsResponse struct {
+	Data       []TradeEvent `json:"data"`
+	NextCursor string       `json:"next_cursor"`
+}

--- a/types/response.go
+++ b/types/response.go
@@ -76,6 +76,26 @@ type MarketsPage struct {
 	Count uint64 `json:"count"`
 }
 
+// SimplifiedMarketResponse represents a simplified market from the CLOB API.
+type SimplifiedMarketResponse struct {
+	// ConditionID is the market condition ID (unique market identifier).
+	ConditionID     *string `json:"condition_id,omitempty"`
+	Tokens          []Token `json:"tokens"`
+	Rewards         Rewards `json:"rewards"`
+	Active          bool    `json:"active"`
+	Closed          bool    `json:"closed"`
+	Archived        bool    `json:"archived"`
+	AcceptingOrders bool    `json:"accepting_orders"`
+}
+
+// SimplifiedMarketsPage represents a paginated list of simplified markets.
+type SimplifiedMarketsPage struct {
+	Data       []SimplifiedMarketResponse `json:"data"`
+	NextCursor string                     `json:"next_cursor"`
+	Limit      uint64                     `json:"limit"`
+	Count      uint64                     `json:"count"`
+}
+
 // OrderSummary represents a single price level in the order book.
 type OrderSummary struct {
 	Price float64 `json:"price"`

--- a/types/response.go
+++ b/types/response.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"encoding/json"
 	"time"
 
 	"github.com/shopspring/decimal"
@@ -8,17 +9,17 @@ import (
 
 // Token represents a market token.
 type Token struct {
-	TokenID string `json:"token_id"`
-	Outcome string `json:"outcome"`
-	Price   string `json:"price,omitempty"`
-	Winner  bool   `json:"winner"`
+	TokenID string      `json:"token_id"`
+	Outcome string      `json:"outcome"`
+	Price   json.Number `json:"price,omitempty"`
+	Winner  bool        `json:"winner"`
 }
 
 // Rewards represents market rewards configuration.
 type Rewards struct {
 	Rates     []RewardRate `json:"rates"`
-	MinSize   string       `json:"min_size"`
-	MaxSpread string       `json:"max_spread"`
+	MinSize   json.Number  `json:"min_size"`
+	MaxSpread json.Number  `json:"max_spread"`
 }
 
 // RewardRate represents a reward rate entry.
@@ -98,20 +99,20 @@ type SimplifiedMarketsPage struct {
 
 // OrderSummary represents a single price level in the order book.
 type OrderSummary struct {
-	Price float64 `json:"price"`
-	Size  float64 `json:"size"`
+	Price json.Number `json:"price"`
+	Size  json.Number `json:"size"`
 }
 
 // OrderBookSummaryResponse represents the response from the order book summary endpoint.
 type OrderBookSummaryResponse struct {
 	Market         string         `json:"market"`
 	AssetID        string         `json:"asset_id"`
-	Timestamp      time.Time      `json:"timestamp"`
+	Timestamp      json.Number    `json:"timestamp"` // Unix timestamp in milliseconds (can be string or number)
 	Hash           *string        `json:"hash,omitempty"`
 	Bids           []OrderSummary `json:"bids"`
 	Asks           []OrderSummary `json:"asks"`
-	MinOrderSize   float64        `json:"min_order_size"`
+	MinOrderSize   json.Number    `json:"min_order_size"`
 	NegRisk        bool           `json:"neg_risk"`
-	TickSize       float64        `json:"tick_size"`
-	LastTradePrice *float64       `json:"last_trade_price,omitempty"`
+	TickSize       json.Number    `json:"tick_size"`
+	LastTradePrice *json.Number   `json:"last_trade_price,omitempty"`
 }

--- a/types/response.go
+++ b/types/response.go
@@ -134,3 +134,30 @@ type MarketTradesEventsResponse struct {
 	Data       []TradeEvent `json:"data"`
 	NextCursor string       `json:"next_cursor"`
 }
+
+type MidpointResponse struct {
+	Mid decimal.Decimal
+}
+
+type MidpointsResponse map[string]decimal.Decimal
+
+type PriceResponse struct {
+	Price decimal.Decimal `json:"price"`
+}
+
+type PricesResponse map[string]map[string]decimal.Decimal
+
+type SpreadResponse struct {
+	Spread decimal.Decimal `json:"spread"`
+}
+
+type SpreadsResponse map[string]decimal.Decimal
+
+type PriceHistoryItem struct {
+	Time  int64           `json:"t"`
+	Price decimal.Decimal `json:"p"`
+}
+
+type PricesHistoryResponse struct {
+	History []PriceHistoryItem `json:"history"`
+}

--- a/types/response.go
+++ b/types/response.go
@@ -116,3 +116,8 @@ type OrderBookSummaryResponse struct {
 	TickSize       json.Number    `json:"tick_size"`
 	LastTradePrice *json.Number   `json:"last_trade_price,omitempty"`
 }
+
+type LastTradePriceResponse struct {
+	Price json.Number `json:"price"`
+	Side  Side        `json:"side,omitempty"`
+}


### PR DESCRIPTION
This PR implements key market data endpoints for the `public_client`, mirroring the structure and functionality of the Rust client. It includes new request/response types, client methods, and comprehensive integration tests (happy path) against the live API.

Closes #8  

## **Key Changes**

### **New Endpoints Implemented**
- **Midpoint** (GET `/midpoint`) & **Midpoints** (POST `/midpoints`)
- **GetPrice** (GET `/price`) & **GetPrices** (POST `/prices`)
- **GetSpread** (GET `/spread`) & **GetSpreads** (POST `/spreads`)
- **GetPricesHistory** (GET `/prices-history`)

### **Type Definitions (`types/request.go`, `types/response.go`, `types/public.go`)**
- Added `SpreadRequest` with support for optional `Side`.
- Added `PricesHistoryRequest` supporting `Market`, `Interval`, `StartTs`, `EndTs`, and `Fidelity`.
- Defined `Interval` enum constants (`1m`, `1h`, `1d`, etc.) to match API expectations.
- Added corresponding response types:
  - `SpreadResponse`, `SpreadsResponse` (Map)
  - `PriceResponse`, `PricesResponse`
  - `PricesHistoryResponse`

### **Client Logic (`clob/public_client.go`)**
- Implemented methods for all new endpoints.
- Added validation logic in `GetPricesHistory` to enforce mutual exclusion between `Interval` and `StartTs`/`EndTs` custom ranges, matching Rust `TimeRange` enum behavior.
- Ensured correct query parameter mapping (snake_case vs camelCase where required, e.g. `startTs`).

### **Integration Tests (`clob/public_client_integration_test.go`, `clob/public_client_price_endpoints_test.go`)**
- Added happy path integration tests for all new endpoints.
- Verified `GetPricesHistory` with both predefined intervals (e.g., `"max"`) and custom time ranges.
- Verified correct parsing of API responses (Maps vs Structs).
- Tested against 429 and 500 status codes also

## **Testing**
- All new integration tests pass against the live Polymarket CLOB API.
- Verified data consistency and correct error handling for invalid request combinations locally.
