### PR TITLE
Feat : Add FeeRate, TickSize, and NegRisk public endpoints

### DIFF
--- a/clob/public_client.go
+++ b/clob/public_client.go
@@ -529,10 +529,7 @@ func (c *PublicClient) GetFeeRateBps(ctx context.Context, req types.FeeRateReque
 	q := url.Values{}
 	q.Add("token_id", req.TokenId)
 
-	u := c.endpoint("/fee-rate")
-	if len(q) > 0 {
-		u = u + "?" + q.Encode()
-	}
+	u := c.endpointWithQuery("/fee-rate", q)
 
 	b, err := c.transport.DoJSON(ctx, http.MethodGet, u, nil, nil)
 	if err != nil {
@@ -551,10 +548,7 @@ func (c *PublicClient) GetTickSize(ctx context.Context, req types.TickSizeReques
 	q := url.Values{}
 	q.Add("token_id", req.TokenId)
 
-	u := c.endpoint("/tick-size")
-	if len(q) > 0 {
-		u = u + "?" + q.Encode()
-	}
+	u := c.endpointWithQuery("/tick-size", q)
 
 	b, err := c.transport.DoJSON(ctx, http.MethodGet, u, nil, nil)
 	if err != nil {
@@ -573,10 +567,7 @@ func (c *PublicClient) GetNegRisk(ctx context.Context, req types.NegRiskRequest)
 	q := url.Values{}
 	q.Add("token_id", req.TokenId)
 
-	u := c.endpoint("/neg-risk")
-	if len(q) > 0 {
-		u = u + "?" + q.Encode()
-	}
+	u := c.endpointWithQuery("/neg-risk", q)
 
 	b, err := c.transport.DoJSON(ctx, http.MethodGet, u, nil, nil)
 	if err != nil {

--- a/clob/public_client.go
+++ b/clob/public_client.go
@@ -524,3 +524,69 @@ func (c *PublicClient) GetPricesHistory(ctx context.Context, req types.PricesHis
 
 	return resp, nil
 }
+
+func (c *PublicClient) GetFeeRateBps(ctx context.Context, req types.FeeRateRequest) (types.FeeRateResponse, error) {
+	q := url.Values{}
+	q.Add("token_id", req.TokenId)
+
+	u := c.endpoint("/fee-rate")
+	if len(q) > 0 {
+		u = u + "?" + q.Encode()
+	}
+
+	b, err := c.transport.DoJSON(ctx, http.MethodGet, u, nil, nil)
+	if err != nil {
+		return types.FeeRateResponse{}, err
+	}
+
+	var resp types.FeeRateResponse
+	if err := json.Unmarshal(b, &resp); err != nil {
+		return types.FeeRateResponse{}, err
+	}
+
+	return resp, nil
+}
+
+func (c *PublicClient) GetTickSize(ctx context.Context, req types.TickSizeRequest) (types.TickSizeResponse, error) {
+	q := url.Values{}
+	q.Add("token_id", req.TokenId)
+
+	u := c.endpoint("/tick-size")
+	if len(q) > 0 {
+		u = u + "?" + q.Encode()
+	}
+
+	b, err := c.transport.DoJSON(ctx, http.MethodGet, u, nil, nil)
+	if err != nil {
+		return types.TickSizeResponse{}, err
+	}
+
+	var resp types.TickSizeResponse
+	if err := json.Unmarshal(b, &resp); err != nil {
+		return types.TickSizeResponse{}, err
+	}
+
+	return resp, nil
+}
+
+func (c *PublicClient) GetNegRisk(ctx context.Context, req types.NegRiskRequest) (types.NegRiskResponse, error) {
+	q := url.Values{}
+	q.Add("token_id", req.TokenId)
+
+	u := c.endpoint("/neg-risk")
+	if len(q) > 0 {
+		u = u + "?" + q.Encode()
+	}
+
+	b, err := c.transport.DoJSON(ctx, http.MethodGet, u, nil, nil)
+	if err != nil {
+		return types.NegRiskResponse{}, err
+	}
+
+	var resp types.NegRiskResponse
+	if err := json.Unmarshal(b, &resp); err != nil {
+		return types.NegRiskResponse{}, err
+	}
+
+	return resp, nil
+}

--- a/clob/public_client_integration_test.go
+++ b/clob/public_client_integration_test.go
@@ -808,3 +808,69 @@ func TestIntegration_GetPricesHistory(t *testing.T) {
 		}
 	}
 }
+
+func TestIntegration_GetFeeRateBps(t *testing.T) {
+	c := getTestClient(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultTimeout)
+	defer cancel()
+
+	tokenID, err := fetchTokenIDFromGamma(ctx)
+	if err != nil {
+		t.Skipf("Could not fetch token_id from Gamma API: %v", err)
+	}
+
+	t.Logf("Testing GetFeeRateBps with token_id: %s", tokenID)
+
+	req := types.FeeRateRequest{TokenId: tokenID}
+	resp, err := c.GetFeeRateBps(ctx, req)
+	if err != nil {
+		t.Fatalf("GetFeeRateBps failed: %v", err)
+	}
+
+	t.Logf("Base Fee: %d", resp.BaseFee)
+}
+
+func TestIntegration_GetTickSize(t *testing.T) {
+	c := getTestClient(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultTimeout)
+	defer cancel()
+
+	tokenID, err := fetchTokenIDFromGamma(ctx)
+	if err != nil {
+		t.Skipf("Could not fetch token_id from Gamma API: %v", err)
+	}
+
+	t.Logf("Testing GetTickSize with token_id: %s", tokenID)
+
+	req := types.TickSizeRequest{TokenId: tokenID}
+	resp, err := c.GetTickSize(ctx, req)
+	if err != nil {
+		t.Fatalf("GetTickSize failed: %v", err)
+	}
+
+	t.Logf("Minimum Tick Size: %v", resp.MinimumTickSize)
+}
+
+func TestIntegration_GetNegRisk(t *testing.T) {
+	c := getTestClient(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultTimeout)
+	defer cancel()
+
+	tokenID, err := fetchTokenIDFromGamma(ctx)
+	if err != nil {
+		t.Skipf("Could not fetch token_id from Gamma API: %v", err)
+	}
+
+	t.Logf("Testing GetNegRisk with token_id: %s", tokenID)
+
+	req := types.NegRiskRequest{TokenId: tokenID}
+	resp, err := c.GetNegRisk(ctx, req)
+	if err != nil {
+		t.Fatalf("GetNegRisk failed: %v", err)
+	}
+
+	t.Logf("Neg Risk: %v", resp.NegRisk)
+}

--- a/types/request.go
+++ b/types/request.go
@@ -32,10 +32,23 @@ type SpreadRequest struct {
 	Side    *Side  `json:"side,omitempty"`
 }
 
+
 type PricesHistoryRequest struct {
 	Market   string   `json:"market"`
 	Interval Interval `json:"interval,omitempty"`
 	StartTs  *int64   `json:"startTs,omitempty"`
 	EndTs    *int64   `json:"endTs,omitempty"`
 	Fidelity *uint32  `json:"fidelity,omitempty"`
+}
+
+type FeeRateRequest struct {
+	TokenId string `json:"token_id"`
+}
+
+type TickSizeRequest struct {
+	TokenId string `json:"token_id"`
+}
+
+type NegRiskRequest struct {
+	TokenId string `json:"token_id"`
 }

--- a/types/response.go
+++ b/types/response.go
@@ -161,3 +161,15 @@ type PriceHistoryItem struct {
 type PricesHistoryResponse struct {
 	History []PriceHistoryItem `json:"history"`
 }
+
+type TickSizeResponse struct {
+	MinimumTickSize decimal.Decimal `json:"minimum_tick_size"`
+}
+
+type NegRiskResponse struct {
+	NegRisk bool `json:"neg_risk"`
+}
+
+type FeeRateResponse struct {
+	BaseFee uint32 `json:"base_fee"`
+}


### PR DESCRIPTION
## Description
This PR implements three new public endpoints for the CLOB client
Closes #19 
To be merged into `feat/public_endpoints`

The new endpoints are:
1. **GetFeeRateBps**: Retrieves the trading fee rate (in basis points) for a market outcome token.
2. **GetTickSize**: Retrieves the minimum tick size for a market outcome token.
3. **GetNegRisk**: Checks if a market outcome token uses the negative risk adapter.

## Changes
- Added `FeeRateRequest`, `TickSizeRequest`, and `NegRiskRequest` structs.
- Added `FeeRateResponse`, `TickSizeResponse`, and `NegRiskResponse` structs.
- Implemented `GetFeeRateBps`, `GetTickSize`, and `GetNegRisk` methods in the public client.
- Added integration tests to verify successful responses from the live Polymarket API for all three endpoints.

## Testing
Ran integration tests against the live API. All tests passed.

```bash
go test -v -tags integration ./clob -run "TestIntegration_Get(FeeRateBps|TickSize|NegRisk)"
