### PR TITLE
ci: add integration test job to run on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,20 @@ jobs:
       - name: Race
         run: go test ./... -race -count=1
 
+  integration:
+    name: Integration Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.24.x"
+          cache: true
+
+      - name: Integration Test
+        run: go test -tags integration ./... -count=1 -v -timeout 120s
+
   lint:
     name: Lint
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Adds a dedicated `integration` job to the CI pipeline that runs the `public_client_integration_test.go` suite against the live Polymarket CLOB API on every PR and push to `main`.

## Why

The integration test file (introduced in #16) was gated behind the `//go:build integration` build tag, meaning it was never executed in CI with a plain `go test ./...`. This left a whole class of bugs undetectable automatically — for example, wrong endpoint paths (like `/events/trade` returning 404) which were only caught during manual review.

Running these on every PR ensures:
- Endpoint paths are correct against the live API
- Response types parse correctly from real responses
- Regressions are caught before merge, not after

## Changes

- `.github/workflows/ci.yml`: new `integration` job running `go test -tags integration ./... -count=1 -v -timeout 120s`

## Notes

- `-count=1` disables test caching so every run hits the live API fresh
- `-timeout 120s` accounts for network latency (default 30s is too tight for live API calls)
- This job has no dependency on secrets — Polymarket's public CLOB endpoints are unauthenticated